### PR TITLE
Make MusicBrainz disc results without date work

### DIFF
--- a/cdparacord/albumdata.py
+++ b/cdparacord/albumdata.py
@@ -152,7 +152,11 @@ class Albumdata:
 
             albumdata['source'] = 'MusicBrainz'
             albumdata['title'] = release['title']
-            albumdata['date'] = release['date']
+            # Sometimes albumdata doesn't seem to have date
+            try:
+                albumdata['date'] = release['date']
+            except KeyError:
+                albumdata['date'] = ''
             albumdata['tracks'] = []
             albumartist = release['artist-credit-phrase']
             albumdata['albumartist'] = albumartist

--- a/tests/test_albumdata.py
+++ b/tests/test_albumdata.py
@@ -568,3 +568,15 @@ def test_generate_filename(monkeypatch, albumdata):
     config.dict['safetyfilter'] = 'fake and not real'
     with pytest.raises(albumdata.AlbumdataError):
         albumdata.Albumdata._generate_filename(testdata, testdata['tracks'][0], 1, config)
+
+def test_disc_result_no_date(monkeypatch, albumdata):
+    """Test that disc result is processed even when lacking date."""
+    monkeypatch.setattr('musicbrainzngs.get_releases_by_discid',
+        lambda x, includes: testdata_disc_result)
+
+    # Delete date, should still work
+    monkeypatch.delitem(testdata_disc_result['disc']['release-list'][0], 'date')
+
+    a = albumdata.Albumdata._albumdata_from_musicbrainz('test')[0]
+
+    assert a['date'] == ''


### PR DESCRIPTION
Earlier we assumed every disc would have a date in all of its releases,
but turns out this isn't true. Now we can handle the no-date case as
well.

Add test for this, too.