### PR TITLE
Move multi-artist check to albumdata constructor

### DIFF
--- a/cdparacord/albumdata.py
+++ b/cdparacord/albumdata.py
@@ -59,10 +59,22 @@ class Albumdata:
         self._ripdir = albumdata['ripdir']
         self._tracks = []
         counter = 0
+
         for trackdata in albumdata['tracks']:
             counter = counter + 1
             trackdata['tracknumber'] = counter
             self._tracks.append(Track(trackdata))
+
+        # Find out if there are multiple artists by seeing if at least
+        # one of the track artists differs from album artist
+        #
+        # This check used to be per-track only later in the rip process
+        # which caused issues.
+        if any(t.artist != self.albumartist for t in self._tracks):
+            self.multiartist = True
+        else:
+            self.multiartist = False
+
 
     @staticmethod
     def _print_albumdata(albumdata):
@@ -306,8 +318,6 @@ class Albumdata:
 
     @classmethod
     def _generate_filename(cls, data, track, tracknumber, config):
-        # TODO: We need the filters here
-        # Also, the templates
         safetyfilter = config.get('safetyfilter')
         target_template = string.Template(config.get('target_template'))
         s = {

--- a/cdparacord/rip.py
+++ b/cdparacord/rip.py
@@ -66,9 +66,10 @@ class Rip:
             audiofile = mutagen.File(temp_encoded, easy=True)
             audiofile.add_tags()
 
-        if (track.artist != self._albumdata.albumartist
+        # We only tag albumartist on multi-artist albums, or if we're
+        # set to always tag albumartist.
+        if (self._albumdata.multiartist
                 or self._config.get('always_tag_albumartist')):
-            # We only tag albumartist Sometimes
             audiofile['albumartist'] = self._albumdata.albumartist
 
         # This is information we always save and presumably always have

--- a/tests/test_albumdata.py
+++ b/tests/test_albumdata.py
@@ -249,6 +249,17 @@ def test_albumdata_tracks(albumdata):
     assert a.albumartist == 'Test Artist'
     assert a.title == 'Test album'
     assert a.date == '2018-01'
+    # This albumdata has a single artist
+    assert a.multiartist == False
+
+    # Also test that we can initialise a multiartist data
+    testdata2 = copy.deepcopy(testdata)
+    testdata2['tracks'][0]['artist'] = 'Test Artist 2'
+    a = albumdata.Albumdata(testdata2)
+    # We now have differing artist and albumartist but otherwise
+    # matching data
+    assert a.multiartist == True
+
 
 
 def test_initialise_albumdata(albumdata):

--- a/tests/test_rip.py
+++ b/tests/test_rip.py
@@ -256,6 +256,10 @@ def test_tag_track(monkeypatch, get_fake_config):
             return 'test'
 
         @property
+        def multiartist(self):
+            return False
+
+        @property
         def title(self):
             return 'test'
 
@@ -291,7 +295,7 @@ def test_tag_track(monkeypatch, get_fake_config):
         def __init__(*a, **b):
             import mutagen
             raise mutagen.MutagenError('something')
-    
+
     monkeypatch.setattr('mutagen.easyid3.EasyID3', FakeFile2)
     monkeypatch.setattr('mutagen.File', FakeFile)
 


### PR DESCRIPTION
This way we'll have the information carried along with the albumdata,
which will make its way into the rip process. Then, instead of checking
whether album and track artists match per-track, we'll simply check if
the album is multi-artist. This fulfills the intent of the
always_tag_albumartist setting which has been buggy thus far.

I'm personally affected by this bug relatively often but for some reason
I had not fixed it before.

Fixes #43 